### PR TITLE
[JBEAP-25577] Respect java proxy options when using URL.openStream

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -40,6 +44,26 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.specto</groupId>
+            <artifactId>hoverfly-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.specto</groupId>
+            <artifactId>hoverfly-java-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -42,6 +42,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
+import org.wildfly.channel.proxy.HttpProxy;
 
 /**
  * Mapper class to transform YAML content (from URL or String) to Channel objects (and vice versa).
@@ -65,6 +66,7 @@ public class ChannelMapper {
     private static final Map<String, JsonSchema> SCHEMAS = new HashMap<>();
 
     static {
+        HttpProxy.setup();
         SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
         SCHEMAS.put(SCHEMA_VERSION_2_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_2_0_0_FILE)));
     }

--- a/core/src/main/java/org/wildfly/channel/proxy/HttpProxy.java
+++ b/core/src/main/java/org/wildfly/channel/proxy/HttpProxy.java
@@ -1,0 +1,94 @@
+package org.wildfly.channel.proxy;
+
+import org.apache.http.HttpHost;
+import org.jboss.logging.Logger;
+
+import java.net.URL;
+
+public abstract class HttpProxy {
+
+    private static final Logger LOG = Logger.getLogger(HttpProxy.class);
+
+    private HttpProxy() {
+    }
+
+    /**
+     * Http Proxy-Authorization Header
+     */
+    static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
+
+    /**
+     * System property to get the http proxy host
+     */
+    static final String HTTP_PROXY_HOST = "http.proxyHost";
+
+    /**
+     * System property to get the http proxy port
+     */
+    static final String HTTP_PROXY_PORT = "http.proxyPort";
+
+
+    /**
+     * System property to get the authenticated http proxy username
+     */
+    static final String HTTP_PROXY_USERNAME = "http.proxyUser";
+
+    /**
+     * System property to get the authenticated http proxy password
+     */
+    static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+
+    /**
+     * System property to get the http proxy protocol
+     */
+    static final String HTTP_PROXY_PROTOCOL = "http.proxyProtocol";
+
+
+    /**
+     * System property to get the https proxy host
+     */
+    static final String HTTPS_PROXY_HOST = "https.proxyHost";
+
+    /**
+     * System property to get the https proxy port
+     */
+    static final String HTTPS_PROXY_PORT = "https.proxyPort";
+
+    /**
+     * System property to get the authenticated https proxy username
+     */
+    static final String HTTPS_PROXY_USERNAME = "https.proxyUser";
+
+    /**
+     * System property to get the authenticated https proxy password
+     */
+    static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
+
+    /**
+     * System property to get the https proxy protocol
+     */
+    static final String HTTPS_PROXY_PROTOCOL = "https.proxyProtocol";
+
+    public static void setup() {
+        try {
+            URL.setURLStreamHandlerFactory(new HttpUrlStreamHandlerFactory());
+        } catch (Error error) {
+            LOG.warn("Unable to URL.setURLStreamHandlerFactory", error);
+        }
+    }
+
+    static void cleanupSystemProperties() {
+        for (SettingsFactory factory : SettingsFactory.values()) {
+            factory.cleanupProperties(System.getProperties());
+        }
+    }
+
+    static HttpHost asHttpHost(URL url) {
+        int port = url.getPort();
+        if (port <= 0) {
+            port = url.getDefaultPort();
+        }
+        HttpHost host = new HttpHost(url.getHost(), port, url.getProtocol());
+        return host;
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/proxy/HttpUrlConnection.java
+++ b/core/src/main/java/org/wildfly/channel/proxy/HttpUrlConnection.java
@@ -1,0 +1,81 @@
+package org.wildfly.channel.proxy;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+class HttpUrlConnection extends URLConnection {
+
+
+    private HttpClient client;
+    private HttpHost host;
+    private HttpRequest request;
+
+
+    public HttpUrlConnection(URL url, HttpClient client, HttpHost host, HttpRequest request) {
+        super(url);
+        this.client = client;
+        this.host = host;
+        this.request = request;
+    }
+
+    private boolean connected;
+
+    private HttpResponse response = null;
+
+    private final ReentrantLock connectionLock = new ReentrantLock();
+
+    private void lock() {
+        connectionLock.lock();
+    }
+
+    private void unlock() {
+        connectionLock.unlock();
+    }
+
+    @Override
+    public void connect() throws IOException {
+        lock();
+        try {
+            if (connected) return;
+            for (Map.Entry<String, List<String>> header : getRequestProperties().entrySet()) {
+                for (String value : header.getValue()) {
+                    request.addHeader(header.getKey(), value);
+                }
+            }
+            response = client.execute(host, request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode < 200 || statusCode >= 300) {
+                OutputStream outputStream = new ByteArrayOutputStream();
+                response.getEntity().getContent().transferTo(outputStream);
+                String errorMessage = outputStream.toString();
+                throw new IOException("Fail to get " + url + ": " + response.getStatusLine() + "\n" + errorMessage);
+            }
+
+
+            this.connected = true;
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (!connected) {
+            connect();
+        }
+        return response.getEntity().getContent();
+    }
+
+}

--- a/core/src/main/java/org/wildfly/channel/proxy/HttpUrlStreamHandler.java
+++ b/core/src/main/java/org/wildfly/channel/proxy/HttpUrlStreamHandler.java
@@ -1,0 +1,73 @@
+package org.wildfly.channel.proxy;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Collections;
+
+import static org.wildfly.channel.proxy.HttpProxy.PROXY_AUTHORIZATION;
+import static org.wildfly.channel.proxy.HttpProxy.asHttpHost;
+
+class HttpUrlStreamHandler extends URLStreamHandler {
+
+    private HttpClient httpClient;
+
+    public HttpUrlStreamHandler() {
+        this(HttpClients.custom().useSystemProperties().build());
+    }
+
+    public HttpUrlStreamHandler(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public Settings getProxySettings(URL url) {
+        SettingsFactory settingsFactory = SettingsFactory.valueOf(url.getProtocol().toUpperCase());
+        return settingsFactory.createFromSystemProperties();
+    }
+
+    @Override
+    protected URLConnection openConnection(URL url) throws IOException {
+        HttpClient client = httpClient;
+        HttpHost targetHost = asHttpHost(url);
+        HttpGet request = new HttpGet(url.getPath());
+        Settings proxySettings = getProxySettings(url);
+        if (proxySettings.isEmpty()) {
+            return new HttpUrlConnection(url, client, targetHost, request);
+        }
+        HttpHost proxyHost = new HttpHost(
+                proxySettings.getHost(),
+                proxySettings.getPort(),
+                proxySettings.getProtocol()
+        );
+        RequestConfig.Builder requestConfigBuilder = RequestConfig.custom()
+                .setProxy(proxyHost);
+        request.setConfig(requestConfigBuilder.build());
+        if (proxySettings.hasCredentials()) {
+            Settings.Credentials credentials = proxySettings.getCredentials();
+            BasicCredentialsProvider basicCredentialsProvider = new BasicCredentialsProvider();
+            basicCredentialsProvider.setCredentials(AuthScope.ANY, credentials.asCredential());
+            requestConfigBuilder.setProxyPreferredAuthSchemes(Collections.singleton(AuthSchemes.BASIC));
+            client = HttpClients.custom()
+                    .useSystemProperties()
+                    .setProxy(proxyHost)
+                    .setDefaultCredentialsProvider(basicCredentialsProvider)
+                    .setDefaultHeaders(Collections.singleton(new BasicHeader(PROXY_AUTHORIZATION, credentials.toBasicAuthorization())))
+                    .build();
+        }
+
+        return new HttpUrlConnection(
+                url, client, targetHost, request
+        );
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/proxy/HttpUrlStreamHandlerFactory.java
+++ b/core/src/main/java/org/wildfly/channel/proxy/HttpUrlStreamHandlerFactory.java
@@ -1,0 +1,27 @@
+package org.wildfly.channel.proxy;
+
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.util.Arrays;
+
+class HttpUrlStreamHandlerFactory implements URLStreamHandlerFactory {
+
+    private final HttpUrlStreamHandler handler;
+
+    public HttpUrlStreamHandlerFactory() {
+        this(new HttpUrlStreamHandler());
+    }
+
+    public HttpUrlStreamHandlerFactory(HttpUrlStreamHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        if (protocol == null) return null;
+        if (Arrays.stream(SettingsFactory.values()).map(SettingsFactory::getProtocol).anyMatch(protocol::equals)) {
+            return handler;
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/proxy/Settings.java
+++ b/core/src/main/java/org/wildfly/channel/proxy/Settings.java
@@ -1,0 +1,112 @@
+package org.wildfly.channel.proxy;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.auth.UsernamePasswordCredentials;
+
+class Settings {
+
+    private String host = null;
+    private int port = -1;
+
+    private String protocol;
+
+    private Credentials credentials = null;
+
+    public Settings() {
+    }
+
+    public Settings(String host, int port, String protocol) {
+        this.host = host;
+        this.port = port;
+        this.protocol = protocol;
+    }
+
+    public Settings(String host, int port, String protocol, Credentials credentials) {
+        this.host = host;
+        this.port = port;
+        this.protocol = protocol;
+        this.credentials = credentials;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public Credentials getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(Credentials credentials) {
+        this.credentials = credentials;
+    }
+
+    public boolean hasCredentials() {
+        return this.credentials != null;
+    }
+
+    public boolean isEmpty() {
+        return host == null || port == -1;
+    }
+
+    static class Credentials {
+        private String username;
+        private String password;
+
+        public Credentials() {
+        }
+
+        public Credentials(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public String toBase64String() {
+            return Base64.encodeBase64String((username + ":" + password).getBytes());
+        }
+
+        public String toBasicAuthorization() {
+            return "Basic " + toBase64String();
+        }
+
+        public UsernamePasswordCredentials asCredential() {
+            return new UsernamePasswordCredentials(username, password);
+        }
+
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/proxy/SettingsFactory.java
+++ b/core/src/main/java/org/wildfly/channel/proxy/SettingsFactory.java
@@ -1,0 +1,94 @@
+package org.wildfly.channel.proxy;
+
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.wildfly.channel.proxy.HttpProxy.*;
+
+enum SettingsFactory {
+
+    HTTP(
+            HTTP_PROXY_HOST,
+            HTTP_PROXY_PORT,
+            HTTP_PROXY_USERNAME,
+            HTTP_PROXY_PASSWORD,
+            HTTP_PROXY_PROTOCOL,
+            "http",
+            80
+    ),
+    HTTPS(
+            HTTPS_PROXY_HOST,
+            HTTPS_PROXY_PORT,
+            HTTPS_PROXY_USERNAME,
+            HTTPS_PROXY_PASSWORD,
+            HTTPS_PROXY_PROTOCOL,
+            "https",
+            443
+    );
+
+    private String host;
+    private String port;
+    private String username;
+    private String password;
+
+    private String protocol;
+
+    private String defaultProtocol;
+    private int defaultPort;
+
+    SettingsFactory(String host, String port, String username, String password, String protocol, String defaultProtocol, int defaultPort) {
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.protocol = protocol;
+        this.defaultProtocol = defaultProtocol;
+        this.defaultPort = defaultPort;
+    }
+
+    public Settings createFromProperties(Properties properties) {
+        String proxyHost = properties.getProperty(host);
+        int proxyPort = Optional.ofNullable(properties.getProperty(port)).map(Integer::parseInt).orElse(defaultPort);
+        String proxyProtocol = Optional.ofNullable(properties.getProperty(protocol)).orElse(defaultProtocol);
+        String proxyUsername = properties.getProperty(username);
+        String proxyPassword = properties.getProperty(password);
+        Settings.Credentials credentials = null;
+        if (proxyUsername != null && proxyPassword != null) {
+            credentials = new Settings.Credentials(proxyUsername, proxyPassword);
+        }
+        return new Settings(proxyHost, proxyPort, proxyProtocol, credentials);
+    }
+
+    public Settings createFromSystemProperties() {
+        return createFromProperties(System.getProperties());
+    }
+
+    public void setProperties(Settings settings, Properties properties) {
+        properties.setProperty(host, settings.getHost());
+        properties.setProperty(port, String.valueOf(settings.getPort()));
+        properties.setProperty(protocol, settings.getProtocol());
+        if (settings.hasCredentials()) {
+            Settings.Credentials credentials = settings.getCredentials();
+            properties.setProperty(username, credentials.getUsername());
+            properties.setProperty(password, credentials.getPassword());
+        }
+    }
+
+    public void setSystemProperties(Settings settings) {
+        setProperties(settings, System.getProperties());
+    }
+
+    public void cleanupProperties(Properties properties) {
+        for (String key : List.of(host, port, username, password)) {
+            properties.remove(key);
+        }
+    }
+
+    public String getProtocol() {
+        return name().toLowerCase();
+    }
+
+    
+}

--- a/core/src/test/java/org/wildfly/channel/proxy/HttpUrlStreamHandlerFactoryTest.java
+++ b/core/src/test/java/org/wildfly/channel/proxy/HttpUrlStreamHandlerFactoryTest.java
@@ -1,0 +1,31 @@
+package org.wildfly.channel.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpUrlStreamHandlerFactoryTest {
+
+    @Test
+    public void canCreate() {
+        URLStreamHandlerFactory handlerFactory = new HttpUrlStreamHandlerFactory();
+        assertThat(handlerFactory).isNotNull();
+    }
+
+    @Test
+    public void shouldHandleOnlyHttpAndHttps() {
+        HttpUrlStreamHandlerFactory handlerFactory = new HttpUrlStreamHandlerFactory();
+        URLStreamHandler httpHandler = handlerFactory.createURLStreamHandler("http");
+        assertThat(httpHandler).isInstanceOf(URLStreamHandler.class);
+        URLStreamHandler httpsHandler = handlerFactory.createURLStreamHandler("https");
+        assertThat(httpsHandler).isInstanceOf(URLStreamHandler.class);
+        for (String protocol : List.of("ftp", "nntp", "file")) {
+            URLStreamHandler handler = handlerFactory.createURLStreamHandler(protocol);
+            assertThat(handler).isNull();
+        }
+    }
+}

--- a/core/src/test/java/org/wildfly/channel/proxy/SettingsTest.java
+++ b/core/src/test/java/org/wildfly/channel/proxy/SettingsTest.java
@@ -1,0 +1,91 @@
+package org.wildfly.channel.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SettingsTest {
+
+    @Test
+    void loadEmptyHttpProperties() {
+        Properties properties = new Properties();
+        Settings settings = SettingsFactory.HTTP.createFromProperties(properties);
+        assertThat(settings.isEmpty()).isTrue();
+    }
+
+    @Test
+    void loadUnauthenticatedHttpProperties() {
+        String host = "localhost";
+        int port = 8080;
+        Properties properties = new Properties();
+        properties.setProperty(HttpProxy.HTTP_PROXY_HOST, host);
+        properties.setProperty(HttpProxy.HTTP_PROXY_PORT, String.valueOf(port));
+        Settings settings = SettingsFactory.HTTP.createFromProperties(properties);
+        assertThat(settings.getHost()).isEqualTo(host);
+        assertThat(settings.getPort()).isEqualTo(port);
+        assertThat(settings.hasCredentials()).isFalse();
+    }
+
+    @Test
+    void loadAuthenticatedHttpProperties() {
+        String host = "localhost";
+        int port = 8080;
+        String username = "user";
+        String password = "password";
+        Properties properties = new Properties();
+        properties.setProperty(HttpProxy.HTTP_PROXY_HOST, host);
+        properties.setProperty(HttpProxy.HTTP_PROXY_PORT, String.valueOf(port));
+        properties.setProperty(HttpProxy.HTTP_PROXY_USERNAME, username);
+        properties.setProperty(HttpProxy.HTTP_PROXY_PASSWORD, password);
+        Settings settings = SettingsFactory.HTTP.createFromProperties(properties);
+        assertThat(settings.getHost()).isEqualTo(host);
+        assertThat(settings.getPort()).isEqualTo(port);
+        assertThat(settings.hasCredentials()).isTrue();
+        Settings.Credentials credentials = settings.getCredentials();
+        assertThat(credentials.getUsername()).isEqualTo(username);
+        assertThat(credentials.getPassword()).isEqualTo(password);
+    }
+
+
+    @Test
+    void loadEmptyHttpsProperties() {
+        Properties properties = new Properties();
+        Settings settings = SettingsFactory.HTTPS.createFromProperties(properties);
+        assertThat(settings.isEmpty()).isTrue();
+    }
+
+    @Test
+    void loadUnauthenticatedHttpsProperties() {
+        String host = "localhost";
+        int port = 8080;
+        Properties properties = new Properties();
+        properties.setProperty(HttpProxy.HTTPS_PROXY_HOST, host);
+        properties.setProperty(HttpProxy.HTTPS_PROXY_PORT, String.valueOf(port));
+        Settings settings = SettingsFactory.HTTPS.createFromProperties(properties);
+        assertThat(settings.getHost()).isEqualTo(host);
+        assertThat(settings.getPort()).isEqualTo(port);
+        assertThat(settings.hasCredentials()).isFalse();
+    }
+
+    @Test
+    void loadAuthenticatedHttpsProperties() {
+        String host = "localhost";
+        int port = 8080;
+        String username = "user";
+        String password = "password";
+        Properties properties = new Properties();
+        properties.setProperty(HttpProxy.HTTPS_PROXY_HOST, host);
+        properties.setProperty(HttpProxy.HTTPS_PROXY_PORT, String.valueOf(port));
+        properties.setProperty(HttpProxy.HTTPS_PROXY_USERNAME, username);
+        properties.setProperty(HttpProxy.HTTPS_PROXY_PASSWORD, password);
+        Settings settings = SettingsFactory.HTTPS.createFromProperties(properties);
+        assertThat(settings.getHost()).isEqualTo(host);
+        assertThat(settings.getPort()).isEqualTo(port);
+        assertThat(settings.hasCredentials()).isTrue();
+        Settings.Credentials credentials = settings.getCredentials();
+        assertThat(credentials.getUsername()).isEqualTo(username);
+        assertThat(credentials.getPassword()).isEqualTo(password);
+    }
+}

--- a/core/src/test/java/org/wildfly/channel/proxy/WithProxyURLTest.java
+++ b/core/src/test/java/org/wildfly/channel/proxy/WithProxyURLTest.java
@@ -1,0 +1,90 @@
+package org.wildfly.channel.proxy;
+
+import io.specto.hoverfly.junit.core.Hoverfly;
+import io.specto.hoverfly.junit5.HoverflyExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+
+import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
+import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
+import static io.specto.hoverfly.junit.dsl.ResponseCreators.success;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(HoverflyExtension.class)
+public class WithProxyURLTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        HttpProxy.setup();
+    }
+
+    @BeforeEach
+    void setUp() {
+        HttpProxy.cleanupSystemProperties();
+    }
+
+    @AfterEach
+    void tearDown() {
+        HttpProxy.cleanupSystemProperties();
+    }
+
+
+    @Test
+    void unauthenticatedHttp(Hoverfly hoverfly) throws Exception {
+        String expected = "bar";
+        hoverfly.simulate(dsl(
+                service("fuu.bar:80")
+                        .get("/fuu")
+                        .willReturn(success().body(expected))
+        ));
+        Settings settings = new Settings(
+                "localhost",
+                hoverfly.getHoverflyConfig().getProxyPort(),
+                "http"
+        );
+        SettingsFactory.HTTP.setSystemProperties(settings);
+
+        URL url = new URL("http://fuu.bar/fuu");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        url.openStream().transferTo(outputStream);
+        String result = outputStream.toString();
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void authenticatedHttp(Hoverfly hoverfly) throws Exception {
+        Settings.Credentials credentials = new Settings.Credentials(
+                "username",
+                "password"
+        );
+        String expected = "bar";
+        hoverfly.simulate(dsl(
+                service("fuu.bar:80")
+                        .get("/fuu")
+                        .header(HttpProxy.PROXY_AUTHORIZATION, credentials.toBasicAuthorization())
+                        .willReturn(success().body(expected))
+        ));
+        hoverfly.getHoverflyConfig().getDestination();
+        Settings settings = new Settings(
+                "localhost",
+                hoverfly.getHoverflyConfig().getProxyPort(),
+                "http",
+                credentials
+        );
+        SettingsFactory.HTTP.setSystemProperties(settings);
+
+        URL url = new URL("http://fuu.bar/fuu");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        url.openStream().transferTo(outputStream);
+        String result = outputStream.toString();
+        assertThat(result).isEqualTo(expected);
+    }
+    
+
+}

--- a/core/src/test/java/org/wildfly/channel/proxy/WithoutProxyURLTest.java
+++ b/core/src/test/java/org/wildfly/channel/proxy/WithoutProxyURLTest.java
@@ -1,0 +1,43 @@
+package org.wildfly.channel.proxy;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+public class WithoutProxyURLTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        HttpProxy.setup();
+    }
+
+    @BeforeEach
+    void setUp() {
+        HttpProxy.cleanupSystemProperties();
+    }
+
+    @Test
+    void testBasicHttpUrl(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String expected = "bar";
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/fuu").willReturn(ok(expected)));
+        URL url = new URL(wmRuntimeInfo.getHttpBaseUrl() + "/fuu");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        url.openStream().transferTo(outputStream);
+        String result = outputStream.toString();
+        assertThat(result).isEqualTo(expected);
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
         <version.junit5>5.9.3</version.junit5>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
+        <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
+        <version.io.specto.hoverfly>0.15.0</version.io.specto.hoverfly>
+        <version.org.mockito>5.3.1</version.org.mockito>
+        <version.org.wiremock>3.0.4</version.org.wiremock>
+        <version.org.assertj>3.24.2</version.org.assertj>
         <version.release.plugin>3.0.1</version.release.plugin>
         <version.maven.resolver-api>1.9.10</version.maven.resolver-api>
         <version.maven.repository.metadata>3.6.3</version.maven.repository.metadata>
@@ -58,6 +63,11 @@
                 <version>${version.org.apache.commons.commons-lang3}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${version.org.apache.httpcomponents.httpclient}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
                 <artifactId>maven-resolver-api</artifactId>
                 <version>${version.maven.resolver-api}</version>
@@ -83,7 +93,27 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.3.1</version>
+                <version>${version.org.mockito}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.specto</groupId>
+                <artifactId>hoverfly-java</artifactId>
+                <version>${version.io.specto.hoverfly}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.specto</groupId>
+                <artifactId>hoverfly-java-junit5</artifactId>
+                <version>${version.io.specto.hoverfly}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${version.org.wiremock}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj}</version>
             </dependency>
             <!-- internal dependencies -->
             <dependency>


### PR DESCRIPTION
The default java implementation ignores http.proxyUser and http.proxyPassword, and the same for the https properties
URL.openStream is called by jackson in OBJECT_MAPPER.readValue(URL)