### PR TITLE
Implement pre-emptive authentication for URL based metadata files

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Blocklist.java
+++ b/core/src/main/java/org/wildfly/channel/Blocklist.java
@@ -18,6 +18,7 @@
 package org.wildfly.channel;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
@@ -85,8 +86,9 @@ public class Blocklist extends VersionedMapper {
          if (!messages.isEmpty()) {
             throw new InvalidChannelMetadataException("Invalid blocklist", messages);
          }
-         Blocklist blocklist = OBJECT_MAPPER.readValue(blocklistUrl, Blocklist.class);
-         return blocklist;
+         try (InputStream input = UrlContentLoader.openStream(blocklistUrl)) {
+            return OBJECT_MAPPER.readValue(input, Blocklist.class);
+         }
       } catch (IOException | URISyntaxException e) {
          throw wrapException(e);
       }
@@ -119,11 +121,13 @@ public class Blocklist extends VersionedMapper {
    }
 
    private static List<String> validate(URL url) throws IOException {
-      JsonNode node = OBJECT_MAPPER.readTree(url);
-      JsonSchema schema = getSchema(node);
-      schema.initializeValidators();
-      Set<ValidationMessage> validationMessages = schema.validate(node);
-      return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+      try (InputStream input = UrlContentLoader.openStream(url)) {
+         JsonNode node = OBJECT_MAPPER.readTree(input);
+         JsonSchema schema = getSchema(node);
+         schema.initializeValidators();
+         Set<ValidationMessage> validationMessages = schema.validate(node);
+         return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+      }
    }
 
    private static JsonSchema getSchema(JsonNode node) {

--- a/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
@@ -30,6 +30,7 @@ import org.wildfly.channel.version.VersionMatcher;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -106,8 +107,9 @@ public class ChannelManifestMapper extends VersionedMapper {
             if (!messages.isEmpty()) {
                 throw new InvalidChannelMetadataException("Invalid manifest", messages);
             }
-            ChannelManifest channelManifest = OBJECT_MAPPER.readValue(manifestURL, ChannelManifest.class);
-            return channelManifest;
+            try (InputStream input = UrlContentLoader.openStream(manifestURL)) {
+                return OBJECT_MAPPER.readValue(input, ChannelManifest.class);
+            }
         } catch (FileNotFoundException e) {
             final InvalidChannelMetadataException ice = new InvalidChannelMetadataException("Unable to resolve manifest.", List.of(manifestURL.toString()));
             ice.initCause(e);
@@ -135,10 +137,12 @@ public class ChannelManifestMapper extends VersionedMapper {
     }
 
     private static List<String> validate(URL url) throws IOException {
-        JsonNode node = OBJECT_MAPPER.readTree(url);
-        JsonSchema schema = getSchema(node);
-        Set<ValidationMessage> validationMessages = schema.validate(node);
-        return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+        try (InputStream input = UrlContentLoader.openStream(url)) {
+            JsonNode node = OBJECT_MAPPER.readTree(input);
+            JsonSchema schema = getSchema(node);
+            Set<ValidationMessage> validationMessages = schema.validate(node);
+            return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+        }
     }
 
     private static List<String> validateString(String yamlContent) throws IOException {

--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -116,7 +117,9 @@ public class ChannelMapper extends VersionedMapper {
             if (!messages.isEmpty()) {
                 throw new InvalidChannelMetadataException("Invalid channel", messages);
             }
-            return OBJECT_MAPPER.readValue(channelURL, Channel.class);
+            try (InputStream input = UrlContentLoader.openStream(channelURL)) {
+                return OBJECT_MAPPER.readValue(input, Channel.class);
+            }
         } catch (IOException | URISyntaxException e) {
             throw wrapException(e);
         }
@@ -139,10 +142,12 @@ public class ChannelMapper extends VersionedMapper {
     }
 
     private static List<String> validate(URL url) throws IOException {
-        JsonNode node = OBJECT_MAPPER.readTree(url);
-        JsonSchema schema = getSchema(node);
-        Set<ValidationMessage> validationMessages = schema.validate(node);
-        return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+        try (InputStream input = UrlContentLoader.openStream(url)) {
+            JsonNode node = OBJECT_MAPPER.readTree(input);
+            JsonSchema schema = getSchema(node);
+            Set<ValidationMessage> validationMessages = schema.validate(node);
+            return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+        }
     }
 
     private static List<String> validateString(String yamlContent) throws IOException {

--- a/core/src/main/java/org/wildfly/channel/UrlContentLoader.java
+++ b/core/src/main/java/org/wildfly/channel/UrlContentLoader.java
@@ -1,0 +1,28 @@
+package org.wildfly.channel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+final class UrlContentLoader {
+
+    static final String HTTP_AUTH_TOKEN_PROPERTY = "org.wildfly.channel.http.auth.token";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private UrlContentLoader() {
+    }
+
+    static InputStream openStream(URL url) throws IOException {
+        URLConnection connection = url.openConnection();
+        String protocol = url.getProtocol();
+        if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
+            String token = System.getProperty(HTTP_AUTH_TOKEN_PROPERTY);
+            if (token != null && !token.isBlank()) {
+                connection.setRequestProperty(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
+            }
+        }
+        return connection.getInputStream();
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/UrlContentLoader.java
+++ b/core/src/main/java/org/wildfly/channel/UrlContentLoader.java
@@ -8,17 +8,36 @@ import java.net.URLConnection;
 final class UrlContentLoader {
 
     static final String HTTP_AUTH_TOKEN_PROPERTY = "org.wildfly.channel.http.auth.token";
+    static final String HTTP_AUTH_TOKEN_ENV_VAR = "WILDFLY_CHANNEL_HTTP_AUTH_TOKEN";
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
     private UrlContentLoader() {
     }
 
+    /**
+     * Retrieves the authentication token from system property or environment variable.
+     * System property takes precedence over environment variable.
+     *
+     * @return the authentication token, or null if not configured
+     */
+    private static String getAuthToken() {
+        // First try system property
+        String token = System.getProperty(HTTP_AUTH_TOKEN_PROPERTY);
+        
+        // Fall back to environment variable if system property is not set or blank
+        if (token == null || token.isBlank()) {
+            token = System.getenv(HTTP_AUTH_TOKEN_ENV_VAR);
+        }
+        
+        return token;
+    }
+
     static InputStream openStream(URL url) throws IOException {
         URLConnection connection = url.openConnection();
         String protocol = url.getProtocol();
         if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
-            String token = System.getProperty(HTTP_AUTH_TOKEN_PROPERTY);
+            String token = getAuthToken();
             if (token != null && !token.isBlank()) {
                 connection.setRequestProperty(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
             }

--- a/core/src/test/java/org/wildfly/channel/UrlContentLoaderTest.java
+++ b/core/src/test/java/org/wildfly/channel/UrlContentLoaderTest.java
@@ -1,0 +1,133 @@
+package org.wildfly.channel;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@WireMockTest
+public class UrlContentLoaderTest {
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY);
+    }
+
+    @Test
+    void sendsBearerAuthorizationHeaderForHttpUrlsWhenTokenIsConfigured(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/secured.yaml")
+                .withHeader("Authorization", WireMock.equalTo("Bearer secret-token"))
+                .willReturn(ok(readResource("channels/remote-authenticated-manifest.yaml"))));
+
+        System.setProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY, "secret-token");
+
+        URL url = new URL(wmRuntimeInfo.getHttpBaseUrl() + "/secured.yaml");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        UrlContentLoader.openStream(url).transferTo(outputStream);
+
+        assertThat(outputStream.toString()).contains("schemaVersion: 1.1.0");
+    }
+
+    @Test
+    void omitsAuthorizationHeaderWhenTokenIsNotConfigured(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/public.yaml")
+                .willReturn(ok(readResource("channels/remote-authenticated-manifest.yaml"))));
+
+        URL url = new URL(wmRuntimeInfo.getHttpBaseUrl() + "/public.yaml");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        UrlContentLoader.openStream(url).transferTo(outputStream);
+
+        assertThat(outputStream.toString()).contains("schemaVersion: 1.1.0");
+    }
+
+    @Test
+    void channelManifestMapperUsesAuthenticatedLoaderForRemoteYaml(WireMockRuntimeInfo wmRuntimeInfo) {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/manifest.yaml")
+                .withHeader("Authorization", WireMock.equalTo("Bearer secret-token"))
+                .willReturn(ok(readResource("channels/remote-authenticated-manifest.yaml"))));
+
+        System.setProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY, "secret-token");
+
+        URL url = asUrl(wmRuntimeInfo.getHttpBaseUrl() + "/manifest.yaml");
+        ChannelManifest manifest = ChannelManifestMapper.from(url);
+
+        assertThat(manifest.getName()).isEqualTo("remote");
+        assertThat(manifest.getStreams()).hasSize(1);
+    }
+
+    @Test
+    void channelMapperUsesAuthenticatedLoaderForRemoteYaml(WireMockRuntimeInfo wmRuntimeInfo) {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/channel.yaml")
+                .withHeader("Authorization", WireMock.equalTo("Bearer secret-token"))
+                .willReturn(ok(readResource("channels/remote-authenticated-channel.yaml"))));
+
+        System.setProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY, "secret-token");
+
+        URL url = asUrl(wmRuntimeInfo.getHttpBaseUrl() + "/channel.yaml");
+        Channel channel = ChannelMapper.from(url);
+
+        assertThat(channel.getName()).isEqualTo("remote");
+        assertThat(channel.getRepositories()).hasSize(1);
+    }
+
+    @Test
+    void blocklistUsesAuthenticatedLoaderForRemoteYaml(WireMockRuntimeInfo wmRuntimeInfo) {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/blocklist.yaml")
+                .withHeader("Authorization", WireMock.equalTo("Bearer secret-token"))
+                .willReturn(ok(readResource("channels/remote-authenticated-blocklist.yaml"))));
+
+        System.setProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY, "secret-token");
+
+        URL url = asUrl(wmRuntimeInfo.getHttpBaseUrl() + "/blocklist.yaml");
+        Blocklist blocklist = Blocklist.from(url);
+
+        assertThat(blocklist.getVersionsFor("org.acme", "artifact")).containsExactly("1.0.0");
+    }
+
+    @Test
+    void channelManifestMapperFailsWithoutTokenForProtectedRemoteYaml(WireMockRuntimeInfo wmRuntimeInfo) {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/manifest.yaml")
+                .willReturn(unauthorized()));
+
+        URL url = asUrl(wmRuntimeInfo.getHttpBaseUrl() + "/manifest.yaml");
+
+        assertThrows(InvalidChannelMetadataException.class, () -> ChannelManifestMapper.from(url));
+    }
+
+    private static URL asUrl(String value) {
+        try {
+            return new URL(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String readResource(String path) {
+        try (var input = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
+            if (input == null) {
+                throw new IllegalArgumentException("Missing test resource: " + path);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/test/java/org/wildfly/channel/UrlContentLoaderTest.java
+++ b/core/src/test/java/org/wildfly/channel/UrlContentLoaderTest.java
@@ -26,6 +26,48 @@ public class UrlContentLoaderTest {
     }
 
     @Test
+    void systemPropertyTakesPrecedenceOverEnvironmentVariable(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(get("/secured.yaml")
+                .withHeader("Authorization", WireMock.equalTo("Bearer system-property-token"))
+                .willReturn(ok(readResource("channels/remote-authenticated-manifest.yaml"))));
+
+        // Set system property - this should take precedence
+        System.setProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY, "system-property-token");
+        
+        // Note: Environment variable WILDFLY_CHANNEL_HTTP_AUTH_TOKEN would be ignored if set
+        // This test verifies that system property takes precedence
+
+        URL url = new URL(wmRuntimeInfo.getHttpBaseUrl() + "/secured.yaml");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        UrlContentLoader.openStream(url).transferTo(outputStream);
+
+        assertThat(outputStream.toString()).contains("schemaVersion: 1.1.0");
+    }
+
+    @Test
+    void blankSystemPropertyFallsBackToEnvironmentVariable(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        
+        // When system property is blank, environment variable should be used
+        // This test documents the expected behavior
+        // To manually verify: set WILDFLY_CHANNEL_HTTP_AUTH_TOKEN=env-token and run test
+        
+        System.setProperty(UrlContentLoader.HTTP_AUTH_TOKEN_PROPERTY, "");
+        
+        // If environment variable is set, it should be used
+        // If not set, no authorization header should be sent
+        wireMock.register(get("/public.yaml")
+                .willReturn(ok(readResource("channels/remote-authenticated-manifest.yaml"))));
+
+        URL url = new URL(wmRuntimeInfo.getHttpBaseUrl() + "/public.yaml");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        UrlContentLoader.openStream(url).transferTo(outputStream);
+
+        assertThat(outputStream.toString()).contains("schemaVersion: 1.1.0");
+    }
+
+    @Test
     void sendsBearerAuthorizationHeaderForHttpUrlsWhenTokenIsConfigured(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         WireMock wireMock = wmRuntimeInfo.getWireMock();
         wireMock.register(get("/secured.yaml")

--- a/core/src/test/resources/channels/remote-authenticated-blocklist.yaml
+++ b/core/src/test/resources/channels/remote-authenticated-blocklist.yaml
@@ -1,0 +1,6 @@
+schemaVersion: 1.0.0
+blocks:
+  - groupId: org.acme
+    artifactId: artifact
+    versions:
+      - 1.0.0

--- a/core/src/test/resources/channels/remote-authenticated-channel.yaml
+++ b/core/src/test/resources/channels/remote-authenticated-channel.yaml
@@ -1,0 +1,8 @@
+schemaVersion: 2.1.0
+name: remote
+description: desc
+repositories:
+  - id: test
+    url: https://repo.example.org/maven2
+manifest:
+  url: https://repo.example.org/manifest.yaml

--- a/core/src/test/resources/channels/remote-authenticated-manifest.yaml
+++ b/core/src/test/resources/channels/remote-authenticated-manifest.yaml
@@ -1,0 +1,6 @@
+schemaVersion: 1.1.0
+name: remote
+streams:
+  - groupId: org.acme
+    artifactId: artifact
+    version: 1.0.0

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -196,6 +196,76 @@ Maven repositories and use the latest version that matches the pattern. If no ve
 
 A channel defines repositories using their `id` and a default `url`. When creating the channel from definition the provisioning tool can replace the provided `url` with URL of a proxy server or an alternative repository. The `id` of the repository must not be changed.
 
+### Authenticating URL-based metadata files
+
+When channel definitions, manifests, or blocklists are hosted on remote servers that require authentication, the WildFly Channel library supports pre-emptive authentication using Bearer tokens.
+
+#### Configuration
+
+Authentication can be configured using either a system property or an environment variable:
+
+* System property: `org.wildfly.channel.http.auth.token`
+* Environment variable: `WILDFLY_CHANNEL_HTTP_AUTH_TOKEN`
+
+The system property takes precedence over the environment variable. If the system property is not set (or is a blank value), the environment variable will be checked as a fallback.
+
+When either configuration is set to a non-blank value, the library will automatically include an `Authorization` header with the Bearer token in all HTTP and HTTPS requests for channel metadata files.
+
+#### Supported resources
+
+Pre-emptive authentication is supported for the following resources when accessed via URL:
+
+* Channel definitions (when using `url` field in channel resolution)
+* Channel manifests (when using `url` field in manifest coordinate definition)
+* Blocklists (when using `url` field in blocklist coordinate definition)
+* Manifest signature files (when using `signature-url` field)
+
+#### Protocol requirements
+
+Authentication is only applied to HTTP and HTTPS URLs. Other protocols (such as `file://`) do not support authentication and will ignore the configured token.
+
+#### Authorization header format
+
+When the `org.wildfly.channel.http.auth.token` property is set to a non-blank value, the library sends the following HTTP header:
+
+```
+Authorization: Bearer <token>
+```
+
+Where `<token>` is the value of the system property.
+
+#### Usage examples
+
+To configure authentication for downloading channel metadata using a system property:
+
+```bash
+java -Dorg.wildfly.channel.http.auth.token=my-secret-token ...
+```
+
+Alternatively, using an environment variable:
+
+```bash
+export WILDFLY_CHANNEL_HTTP_AUTH_TOKEN=my-secret-token
+java ...
+```
+
+Or set inline:
+
+```bash
+WILDFLY_CHANNEL_HTTP_AUTH_TOKEN=my-secret-token java ...
+```
+
+Any of these configurations will cause all HTTP/HTTPS requests for channel, manifest, and blocklist files to include the Bearer token in the Authorization header.
+
+[NOTE]
+====
+The authentication token is sent with every HTTP/HTTPS request for metadata files. Ensure that:
+
+* The token is kept secure and not exposed in logs or version control
+* HTTPS is used when transmitting sensitive tokens to prevent interception
+* The token has appropriate permissions for accessing the required resources
+====
+
 ### Blocking artifact versions
 When using an open channel, a situation may arise where certain artifacts are promoted to the channel and later discovered to be invalid. As it’s impossible to remove artifacts already deployed into a repository, those versions have to blocklisted.
 


### PR DESCRIPTION
The auth token is read from the org.wildfly.channel.http.auth.token system property.

AI assisted (IBM Bob).

Resolves https://github.com/wildfly/wildfly-channel/issues/401